### PR TITLE
added support service version as number

### DIFF
--- a/registry/serviceCatalog.go
+++ b/registry/serviceCatalog.go
@@ -219,7 +219,7 @@ func (serviceCatalog *ServiceCatalog) updateActions(serviceMap map[string]interf
 // updateRemote : update remote service info and return what actions are new, updated and deleted
 func (serviceCatalog *ServiceCatalog) updateRemote(nodeID string, serviceInfo map[string]interface{}) (*service.Service, bool, []map[string]interface{}, []service.Action, []service.Action, []map[string]interface{}, []service.Event, []service.Event) {
 
-	key := createKey(serviceInfo["name"].(string), serviceInfo["version"].(string), nodeID)
+	key := createKey(serviceInfo["name"].(string), service.ParseVersion(serviceInfo["version"]), nodeID)
 	item, serviceExists := serviceCatalog.services.Load(key)
 
 	if serviceExists {

--- a/service/service.go
+++ b/service/service.go
@@ -69,6 +69,26 @@ type HasEvents interface {
 	Events() []moleculer.Event
 }
 
+func ParseVersion(iver interface{}) string {
+
+	v, ok := iver.(string)
+	if ok {
+		return v
+	}
+
+	f, ok := iver.(float64)
+	if ok {
+		return fmt.Sprintf("%g", f)
+	}
+
+	i, ok := iver.(int64)
+	if ok {
+		return fmt.Sprintf("%d", i)
+	}
+
+	return fmt.Sprintf("%v", iver)
+}
+
 type Service struct {
 	nodeID       string
 	fullname     string
@@ -460,7 +480,7 @@ func populateFromMap(service *Service, serviceInfo map[string]interface{}) {
 	if nodeID, ok := serviceInfo["nodeID"]; ok {
 		service.nodeID = nodeID.(string)
 	}
-	service.version = serviceInfo["version"].(string)
+	service.version = ParseVersion(serviceInfo["version"])
 	service.name = serviceInfo["name"].(string)
 	service.fullname = joinVersionToName(
 		service.name,

--- a/service/service_internal_test.go
+++ b/service/service_internal_test.go
@@ -453,6 +453,17 @@ var _ = Describe("Service", func() {
 		Expect(fn).Should(BeNil())
 	})
 
+	It("ParseVersion()", func() {
+		intVer := 1
+		Expect(ParseVersion(intVer)).Should(Equal("1"))
+
+		floatVer := 1.1
+		Expect(ParseVersion(floatVer)).Should(Equal("1.1"))
+
+		strVer := "v0.1.1"
+		Expect(ParseVersion(strVer)).Should(Equal("v0.1.1"))
+	})
+
 })
 
 type NoPointers struct {


### PR DESCRIPTION
Hello (again)

I met a problem when the "remote" (nodejs) service has a version in the form of a number. This crashes the program.