### PR TITLE
fix key in actions map

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -372,7 +372,7 @@ func (service *Service) AsMap() map[string]interface{} {
 			actionInfo["name"] = serviceAction.fullname
 			actionInfo["rawName"] = serviceAction.name
 			actionInfo["params"] = paramsAsMap(&serviceAction.params)
-			actions[serviceAction.name] = actionInfo
+			actions[serviceAction.fullname] = actionInfo
 		}
 	}
 	serviceInfo["actions"] = actions


### PR DESCRIPTION
Hello.

We tested the work with moleculer-nodejs(0.13.12) services and found a problem in the message format mismatch (INFO).

The nodejs services have format (for actions list)
```
actions: {
  'v1.config.getConfigs': {
    params: { env: [Object] },
    rawName: 'getConfigs',
    name: 'v1.config.getConfigs',
    cache: false,
    metrics: { params: false, meta: true }
  },
  'v1.config.getSharedAdapters': {
    params: { env: [Object] },
    rawName: 'getSharedAdapters',
    name: 'v1.config.getSharedAdapters',
    cache: false,
    metrics: { params: false, meta: true }
  }
}
```

The key in the actions list matches the full name of the service

But go services have a different format:
```
actions: { 
    'get': { 
      name: 'testservice.get', 
      params: {}, 
      rawName: 'get' 
    } 
}
```

key='get' but name='testservice.get',

This leads to incorrect processing of the actions list in the nodejs and setting the flag `available=false` for moleculer-go service.

This patch fixes this problem.