### PR TITLE
fix actions name (added version if exists)

### DIFF
--- a/registry/actionCatalog.go
+++ b/registry/actionCatalog.go
@@ -112,9 +112,13 @@ func (actionCatalog *ActionCatalog) listByName() map[string][]ActionEntry {
 }
 
 // Add a new action to the catalog.
-func (actionCatalog *ActionCatalog) Add(action service.Action, service *service.Service, local bool) {
-	entry := ActionEntry{service.NodeID(), &action, local, service, actionCatalog.logger}
+func (actionCatalog *ActionCatalog) Add(action service.Action, serv *service.Service, local bool) {
+	entry := ActionEntry{serv.NodeID(), &action, local, serv, actionCatalog.logger}
 	name := action.FullName()
+	ver := serv.Version()
+	if ver != "" && !strings.HasPrefix(name, ver) {
+		name = service.JoinVersionToName(name, ver)
+	}
 	list, exists := actionCatalog.actions.Load(name)
 	if !exists {
 		list = []ActionEntry{entry}

--- a/registry/serviceCatalog.go
+++ b/registry/serviceCatalog.go
@@ -206,7 +206,7 @@ func (serviceCatalog *ServiceCatalog) updateActions(serviceMap map[string]interf
 		}
 	}
 	for _, action := range current.Actions() {
-		name := action.Name()
+		name := action.FullName()
 		_, exists := actions[name]
 		if !exists {
 			deletedActions = append(deletedActions, action)

--- a/service/service.go
+++ b/service/service.go
@@ -324,7 +324,7 @@ func applyMixins(service moleculer.ServiceSchema) moleculer.ServiceSchema {
 	return service
 }
 
-func joinVersionToName(name string, version string) string {
+func JoinVersionToName(name string, version string) string {
 	if version != "" {
 		return fmt.Sprintf("%s.%s", version, name)
 	}
@@ -482,7 +482,7 @@ func populateFromMap(service *Service, serviceInfo map[string]interface{}) {
 	}
 	service.version = ParseVersion(serviceInfo["version"])
 	service.name = serviceInfo["name"].(string)
-	service.fullname = joinVersionToName(
+	service.fullname = JoinVersionToName(
 		service.name,
 		service.version)
 
@@ -506,7 +506,7 @@ func (service *Service) populateFromSchema() {
 	schema := service.schema
 	service.name = schema.Name
 	service.version = schema.Version
-	service.fullname = joinVersionToName(service.name, service.version)
+	service.fullname = JoinVersionToName(service.name, service.version)
 	service.dependencies = schema.Dependencies
 	service.settings = schema.Settings
 	if service.settings == nil {


### PR DESCRIPTION
Hello (again)..
During testing, we found the problem of calling functions on services if they have a version specified.
Local functions are adding correctly (with the version in the name). But for some reason, the functions of remote services are added without a version in the name.

This patch corrects function names.

P.S. I'm not completely sure that this is the correct fix, but it helped us.
