### PR TITLE
Fix handling of empty gossip message

### DIFF
--- a/transit/tcp/gossip.go
+++ b/transit/tcp/gossip.go
@@ -8,6 +8,7 @@ import (
 	"github.com/moleculer-go/moleculer"
 	payloadPkg "github.com/moleculer-go/moleculer/payload"
 	"github.com/moleculer-go/moleculer/util"
+	log "github.com/sirupsen/logrus"
 )
 
 func (transporter *TCPTransporter) startGossipTimer() {
@@ -45,9 +46,7 @@ func (transporter *TCPTransporter) getRandomNode(nodes []moleculer.Node) molecul
 func (transporter *TCPTransporter) sendGossip(nodeID string, payload moleculer.Payload) {
 	node := transporter.registry.GetNodeByID(nodeID)
 	if !node.IsLocal() {
-		transporter.logger.Trace("GOSSIP SEND - About to send gossip to nodeID:", nodeID, "payload size:", len(util.PrettyPrintMap(payload.RawMap())))
 		transporter.Publish(msgTypeToCommand(PACKET_GOSSIP_REQ), node.GetID(), payload)
-		transporter.logger.Trace("GOSSIP SEND - Gossip sent successfully to nodeID:", nodeID)
 	}
 }
 
@@ -66,11 +65,11 @@ func (transporter *TCPTransporter) onGossipHello(fromAddrss string, payload mole
 	port := payload.Get("port").Int()
 	hostname := payload.Get("host").String()
 
-	transporter.logger.Debug("Received gossip hello from sender: ", sender, "ipAddress: ", fromAddrss, " hostname: ", hostname)
+	transporter.logger.Trace("Received gossip hello from sender: ", sender, "ipAddress: ", fromAddrss, " hostname: ", hostname)
 
 	node := transporter.registry.GetNodeByID(sender)
 	if node == nil {
-		transporter.logger.Debug("Unknown node. Register as offline node - sender: ", sender)
+		transporter.logger.Trace("Unknown node. Register as offline node - sender: ", sender)
 		// Extract just the IP address from the full address
 		ipAddress, _, err := net.SplitHostPort(fromAddrss)
 		if err != nil {
@@ -91,12 +90,10 @@ func (transporter *TCPTransporter) onGossipHello(fromAddrss string, payload mole
 		})
 	}
 	node.Available()
-	transporter.logger.Trace("will send a gossip response to node: " + sender)
 	transporter.onGossipRequest(payloadPkg.Empty().Add("sender", sender))
 }
 
 func (transporter *TCPTransporter) sendGossipRequest(target string) {
-	transporter.logger.Trace("Sending gossip request")
 	node := transporter.registry.GetLocalNode()
 	node.UpdateMetrics()
 	onlineResponse := map[string]interface{}{}
@@ -127,21 +124,19 @@ func (transporter *TCPTransporter) sendGossipRequest(target string) {
 	if len(onlineResponse) > 0 {
 		var targetNode moleculer.Node
 		if target != "" {
-			transporter.logger.Debug("target node is specified target:", target)
+			transporter.logger.Trace("target node is specified target:", target)
 			targetNode = transporter.registry.GetNodeByID(target)
 		}
 		if targetNode == nil {
 			targetNode = transporter.getRandomNode(onlineNodes)
 			if targetNode != nil {
-				transporter.logger.Trace("selected a random node to send gossip request - nodeId:", targetNode.GetID())
 			} else {
-				transporter.logger.Trace("could not select a random node  - online nodes size:", len(onlineNodes))
 			}
 		}
 		if targetNode != nil {
 			transporter.sendGossip(targetNode.GetID(), payload)
 		} else {
-			transporter.logger.Debug("No target node found for gossip request - target param:", target, " online nodes size:", len(onlineNodes))
+			transporter.logger.Trace("No target node found for gossip request - target param:", target, " online nodes size:", len(onlineNodes))
 		}
 	}
 
@@ -157,7 +152,7 @@ func (transporter *TCPTransporter) sendGossipRequest(target string) {
 func (transporter *TCPTransporter) onGossipRequest(payload moleculer.Payload) {
 	sender := payload.Get("sender").String()
 
-	transporter.logger.Debug("onGossipRequest() - sender:" + sender)
+	transporter.logger.Trace("onGossipRequest() - sender:" + sender)
 
 	onlineResponse := map[string]interface{}{}
 	offlineResponse := map[string]interface{}{}
@@ -175,14 +170,13 @@ func (transporter *TCPTransporter) onGossipRequest(payload moleculer.Payload) {
 		if offlineMap.Exists() {
 			offline = offlineMap.Get(node.GetID())
 			if offline.Exists() {
-				transporter.logger.Debug("received seq for " + node.GetID())
+				transporter.logger.Trace("received seq for " + node.GetID())
 				seq = offline.Int64()
 			}
 		}
 		if onlineMap.Exists() {
 			online = onlineMap.Get(node.GetID())
 			if online.Exists() {
-				transporter.logger.Trace("received for: "+node.GetID(), " seq: ", seq, " cpuSeq: ", cpuSeq, " cpu: ", cpu)
 				seq = online.Get("seq").Int64()
 				cpuSeq = online.Get("cpuSeq").Int64()
 				cpu = online.Get("cpu").Int64()
@@ -190,22 +184,24 @@ func (transporter *TCPTransporter) onGossipRequest(payload moleculer.Payload) {
 		}
 
 		if seq != 0 && seq < node.GetSequence() {
-			transporter.logger.Debug("We have newer info or requester doesn't know it")
+			transporter.logger.Trace("We have newer info or requester doesn't know it")
 			if node.IsAvailable() {
 				info := node.ExportAsMap()
 				onlineResponse[node.GetID()] = []interface{}{info, node.GetCpuSequence(), node.GetCpu()}
-				transporter.logger.Debug("Node is available - send back the node info and cpu, cpuSed to "+node.GetID(), " seq: ", seq, " cpuSeq: ", cpuSeq, " cpu: ", cpu, " info: ", util.PrettyPrintMap(info))
+				if log.GetLevel() >= log.TraceLevel {
+					transporter.logger.Trace("Node is available - send back the node info and cpu, cpuSeq to "+node.GetID(), " seq: ", seq, " cpuSeq: ", cpuSeq, " cpu: ", cpu, " info: ", util.PrettyPrintMap(info))
+				}
 			} else {
 				offlineResponse[node.GetID()] = node.GetSequence()
-				transporter.logger.Debug("Node is offline - send back the seq to " + node.GetID())
+				transporter.logger.Trace("Node is offline - send back the seq to " + node.GetID())
 			}
 			return true
 		}
 
 		if offline != nil && offline.Exists() {
-			transporter.logger.Debug("Requester said it is OFFLINE")
+			transporter.logger.Trace("Requester said it is OFFLINE")
 			if !node.IsAvailable() {
-				transporter.logger.Debug("We also know it as offline - update the seq")
+				transporter.logger.Trace("We also know it as offline - update the seq")
 				if seq > node.GetSequence() {
 					node.UpdateInfo(map[string]interface{}{
 						"seq": seq,
@@ -215,7 +211,7 @@ func (transporter *TCPTransporter) onGossipRequest(payload moleculer.Payload) {
 			}
 
 			if !node.IsLocal() {
-				transporter.logger.Debug("our current state for it is online - change it to offline and update seq - nodeID:", node.GetID(), "seq:", seq)
+				transporter.logger.Trace("our current state for it is online - change it to offline and update seq - nodeID:", node.GetID(), "seq:", seq)
 				// We know it is online, so we change it to offline
 				transporter.registry.DisconnectNode(node.GetID())
 
@@ -227,7 +223,7 @@ func (transporter *TCPTransporter) onGossipRequest(payload moleculer.Payload) {
 			}
 
 			if node.IsLocal() {
-				transporter.logger.Debug("msg is about the Local node - update the seq and send back info, cpu and cpuSeq")
+				transporter.logger.Trace("msg is about the Local node - update the seq and send back info, cpu and cpuSeq")
 				// Update the 'seq' to the received value
 				node.UpdateInfo(map[string]interface{}{
 					"seq": seq + 1,
@@ -246,11 +242,11 @@ func (transporter *TCPTransporter) onGossipRequest(payload moleculer.Payload) {
 						"cpu":    cpu,
 						"cpuSeq": cpuSeq,
 					})
-					transporter.logger.Debug("CPU info updated for " + node.GetID())
+					transporter.logger.Trace("CPU info updated for " + node.GetID())
 				} else if cpuSeq < node.GetCpuSequence() {
 					// We have newer info, send back
 					onlineResponse[node.GetID()] = []interface{}{node.ExportAsMap(), node.GetCpuSequence(), node.GetCpu()}
-					transporter.logger.Debug("CPU info sent back to " + node.GetID())
+					transporter.logger.Trace("CPU info sent back to " + node.GetID())
 				}
 			} else {
 				// We know it as offline. We do nothing, because we'll request it and we'll receive its INFO.
@@ -277,10 +273,8 @@ func (transporter *TCPTransporter) onGossipRequest(payload moleculer.Payload) {
 		if len(offlineResponse) > 0 {
 			responsePayload.Add("offline", offlineResponse)
 		}
-		transporter.logger.Trace("Gossip response sent to "+sender, " payload:", util.PrettyPrintMap(responsePayload.RawMap()))
 		transporter.Publish(msgTypeToCommand(PACKET_GOSSIP_RES), sender, responsePayload)
 	} else {
-		transporter.logger.Trace("No response sent to " + sender)
 	}
 
 }
@@ -288,54 +282,32 @@ func (transporter *TCPTransporter) onGossipRequest(payload moleculer.Payload) {
 func (transporter *TCPTransporter) onGossipResponse(payload moleculer.Payload) {
 	sender := payload.Get("sender").String()
 
-	transporter.logger.Trace("Received gossip response from "+sender, " payload:", util.PrettyPrintMap(payload.RawMap()))
-
 	online := payload.Get("online")
 	offline := payload.Get("offline")
 
 	if online.Exists() {
-		transporter.logger.Trace("Received online info from nodeID: " + sender)
 		online.ForEach(func(key interface{}, value moleculer.Payload) bool {
 			nodeID, ok := key.(string)
-			transporter.logger.Debug("Received online info from nodeID: " + nodeID)
+			transporter.logger.Trace("Received online info from nodeID: " + nodeID)
 			if !ok {
 				transporter.logger.Error("Error parsing online nodeID")
 				return true
 			}
 			node := transporter.registry.GetNodeByID(nodeID)
 			if node != nil && node.IsLocal() {
-				transporter.logger.Debug("Received info about the local node - ignore it")
+				transporter.logger.Trace("Received info about the local node - ignore it")
 				return true
 			}
 			row := online.Get(nodeID).Array()
-			transporter.logger.Trace("Parsing gossip response row for nodeID:", nodeID, "row:", util.PrettyPrintMap(row))
 			info, cpu, cpuSeq := parseGossipResponse(row)
-			transporter.logger.Trace("Parsed gossip response - info:", util.PrettyPrintMap(info.RawMap()), "cpu:", cpu, "cpuSeq:", cpuSeq)
 
 			if info != nil && (node == nil || node.GetSequence() < info.Get("seq").Int64()) {
-				transporter.logger.Debug("If we don't know it, or know, but has smaller seq, update 'info'")
-				currentSeq := int64(0)
-				if node != nil {
-					currentSeq = node.GetSequence()
-				}
-				transporter.logger.Trace("Current node sequence:", currentSeq, "incoming sequence:", info.Get("seq").Int64())
+				transporter.logger.Trace("If we don't know it, or know, but has smaller seq, update 'info'")
 				info = info.Add("sender", sender)
-				transporter.logger.Trace("Calling RemoteNodeInfoReceived with info:", util.PrettyPrintMap(info.RawMap()))
 				transporter.registry.RemoteNodeInfoReceived(info)
-				transporter.logger.Trace("RemoteNodeInfoReceived completed for nodeID:", nodeID)
-			} else {
-				currentSeq := int64(0)
-				if node != nil {
-					currentSeq = node.GetSequence()
-				}
-				incomingSeq := int64(0)
-				if info != nil {
-					incomingSeq = info.Get("seq").Int64()
-				}
-				transporter.logger.Trace("Skipping node update - info is nil or sequence not newer. node:", node != nil, "info:", info != nil, "currentSeq:", currentSeq, "incomingSeq:", incomingSeq)
 			}
 			if node != nil && cpuSeq > node.GetCpuSequence() {
-				transporter.logger.Debug("If we know it and has smaller cpuSeq, update 'cpu'")
+				transporter.logger.Trace("If we know it and has smaller cpuSeq, update 'cpu'")
 				node.HeartBeat(map[string]interface{}{
 					"cpu":    cpu,
 					"cpuSeq": cpuSeq,
@@ -346,7 +318,7 @@ func (transporter *TCPTransporter) onGossipResponse(payload moleculer.Payload) {
 	}
 
 	if offline.Exists() {
-		transporter.logger.Debug("Received offline info from nodeID: " + sender)
+		transporter.logger.Trace("Received offline info from nodeID: " + sender)
 		offline.ForEach(func(key interface{}, value moleculer.Payload) bool {
 			nodeID, ok := key.(string)
 			if !ok {
@@ -355,7 +327,7 @@ func (transporter *TCPTransporter) onGossipResponse(payload moleculer.Payload) {
 			}
 			node := transporter.registry.GetNodeByID(nodeID)
 			if node != nil && node.IsLocal() {
-				transporter.logger.Debug("Received info about the local node - ignore it")
+				transporter.logger.Trace("Received info about the local node - ignore it")
 				return true
 			}
 			if node == nil {
@@ -366,7 +338,7 @@ func (transporter *TCPTransporter) onGossipResponse(payload moleculer.Payload) {
 
 			if node.GetSequence() < seq {
 				if node.IsAvailable() {
-					transporter.logger.Debug("Node is online, will change it to offline")
+					transporter.logger.Trace("Node is online, will change it to offline")
 					transporter.registry.DisconnectNode(nodeID)
 				}
 				node.UpdateInfo(map[string]interface{}{

--- a/transit/tcp/tcp-transporter.go
+++ b/transit/tcp/tcp-transporter.go
@@ -297,7 +297,7 @@ func (transporter *TCPTransporter) incomingMessage(msgType int, msgBytes *[]byte
 		transporter.logger.Error("Unknown command received - msgType: " + strconv.Itoa(msgType))
 		return
 	}
-	transporter.logger.Debug("Incoming message - command: " + command)
+	transporter.logger.Trace("Incoming message - command: " + command)
 	message := transporter.serializer.BytesToPayload(msgBytes)
 	// if transporter.validateMsg(message) {
 	transporter.handlersLock.RLock()
@@ -435,10 +435,10 @@ func addIpToList(ipList []string, address string) []string {
 // need to find where the TCP connection step happens.. is not happening here - where is this node info used ?
 func (transporter *TCPTransporter) onUdpMessage(nodeID, host string, port int) {
 	if nodeID != "" && nodeID != transporter.options.NodeId {
-		transporter.logger.Debug("UDP discovery received from " + host + " nodeId: " + nodeID + " port: " + strconv.Itoa(port))
+		transporter.logger.Trace("UDP discovery received from " + host + " nodeId: " + nodeID + " port: " + strconv.Itoa(port))
 		node := transporter.registry.GetNodeByID(nodeID)
 		if node == nil {
-			transporter.logger.Debug("Unknown node. Register as offline node")
+			transporter.logger.Trace("Unknown node. Register as offline node")
 			node = transporter.registry.AddOfflineNode(nodeID, host, host, port)
 			transporter.sendGossipHello(nodeID)
 
@@ -532,7 +532,9 @@ func (transporter *TCPTransporter) Publish(command, nodeID string, message molec
 		//handled by the gossip protocol
 		return
 	}
-	transporter.logger.Trace("TCPTransporter.Publish() command: "+command+" to nodeID: "+nodeID, " message: ", util.PrettyPrintMap(message.RawMap()))
+	if log.GetLevel() >= log.TraceLevel {
+		transporter.logger.Trace("TCPTransporter.Publish() command: "+command+" to nodeID: "+nodeID, " message: ", util.PrettyPrintMap(message.RawMap()))
+	}
 
 	msgType := commandToMsgType(command)
 	if msgType == -1 {

--- a/transit/tcp/tcp-writer.go
+++ b/transit/tcp/tcp-writer.go
@@ -221,7 +221,7 @@ func (w *TcpWriter) cleanupIdleConnections() {
 	now := time.Now()
 	for nodeID, socket := range w.sockets {
 		if now.Sub(socket.lastUsed) > w.idleTimeout {
-			w.logger.Debug("Closing idle connection for nodeID:", nodeID)
+			w.logger.Trace("Closing idle connection for nodeID:", nodeID)
 			socket.conn.Close()
 			delete(w.sockets, nodeID)
 		}

--- a/transit/tcp/udp.go
+++ b/transit/tcp/udp.go
@@ -186,11 +186,11 @@ func (u *UdpServer) Start() error {
 		}
 
 		if hasLocalhost {
-			u.logger.Debug("Localhost detected - using broadcast instead of multicast for better localhost compatibility")
+			u.logger.Trace("Localhost detected - using broadcast instead of multicast for better localhost compatibility")
 			broadcastAddrss := u.getBroadcastAddresses()
 			// Add localhost broadcast for localhost discovery
 			broadcastAddrss = append(broadcastAddrss, "127.0.0.1")
-			u.logger.Debug("Starting UDP server on IP (BindAddress):", u.opts.BindAddress, "Port:", u.opts.Port, "Broadcasting to all interfaces - broadcastAddrss: ", broadcastAddrss)
+			u.logger.Trace("Starting UDP server on IP (BindAddress):", u.opts.BindAddress, "Port:", u.opts.Port, "Broadcasting to all interfaces - broadcastAddrss: ", broadcastAddrss)
 			err := u.startServer(u.opts.BindAddress, u.opts.Port, "", 0, broadcastAddrss)
 			if err != nil {
 				return err
@@ -199,25 +199,25 @@ func (u *UdpServer) Start() error {
 		}
 
 		if u.opts.BindAddress != "" {
-			u.logger.Debug("Multicast + BindAddress options specified - Binding to a specific interface:", u.opts.BindAddress)
+			u.logger.Trace("Multicast + BindAddress options specified - Binding to a specific interface:", u.opts.BindAddress)
 			// Bind only one interface
 			return u.startServer(u.opts.BindAddress, u.opts.Port, u.opts.Multicast, u.opts.MulticastTTL, []string{u.opts.Multicast})
 		}
 		//list all interfaces and the ip addresses of each interface
-		u.logger.Debug("Multicast option specified - listing all interfaces and the ip addresses of each interface")
+		u.logger.Trace("Multicast option specified - listing all interfaces and the ip addresses of each interface")
 		for _, ip := range ips {
-			u.logger.Debug("Starting UDP server on IP:", ip, "Port:", u.opts.Port, "Multicast:", u.opts.Multicast, "MulticastTTL:", u.opts.MulticastTTL)
+			u.logger.Trace("Starting UDP server on IP:", ip, "Port:", u.opts.Port, "Multicast:", u.opts.Multicast, "MulticastTTL:", u.opts.MulticastTTL)
 			err := u.startServer(ip, u.opts.Port, u.opts.Multicast, u.opts.MulticastTTL, []string{u.opts.Multicast})
 			if err != nil {
 				u.logger.Error("Error starting server on IP:", ip, err)
 			}
 		}
 	} else if len(u.opts.BroadcastAddrs) > 0 {
-		u.logger.Debug("Starting UDP server on IP (BindAddress):", u.opts.BindAddress, "Port:", u.opts.Port, " BroadcastAddrs option specified - Broadcasting to the specified addresses - BroadcastAddrs:", u.opts.BroadcastAddrs)
+		u.logger.Trace("Starting UDP server on IP (BindAddress):", u.opts.BindAddress, "Port:", u.opts.Port, " BroadcastAddrs option specified - Broadcasting to the specified addresses - BroadcastAddrs:", u.opts.BroadcastAddrs)
 		return u.startServer(u.opts.BindAddress, u.opts.Port, "", 0, u.opts.BroadcastAddrs)
 	} else {
 		broadcastAddrss := u.getBroadcastAddresses()
-		u.logger.Debug("Starting UDP server on IP (BindAddress):", u.opts.BindAddress, "Port:", u.opts.Port, "No Multicast or BroadcastAddrs options specified - Broadcasting to all interfaces - broadcastAddrss: ", broadcastAddrss)
+		u.logger.Trace("Starting UDP server on IP (BindAddress):", u.opts.BindAddress, "Port:", u.opts.Port, "No Multicast or BroadcastAddrs options specified - Broadcasting to all interfaces - broadcastAddrss: ", broadcastAddrss)
 		return u.startServer(u.opts.BindAddress, u.opts.Port, "", 0, broadcastAddrss)
 	}
 
@@ -337,7 +337,7 @@ func (u *UdpServer) handleIncomingMessagesForServer(server *UdpServerEntry) {
 
 		u.onUdpMessage(nodeID, addr.IP.String(), port)
 	}
-	u.logger.Debug("handleIncomingMessagesForServer() stopped")
+	u.logger.Trace("handleIncomingMessagesForServer() stopped")
 }
 
 func (u *UdpServer) startDiscovering() {
@@ -364,7 +364,7 @@ func (u *UdpServer) startDiscovering() {
 func (u *UdpServer) BroadcastDiscoveryMessage() {
 	node := u.registry.GetLocalNode()
 	message := fmt.Sprintf("%s|%s|%d", u.opts.Namespace, node.GetID(), node.GetPort())
-	u.logger.Debug("Broadcasting discovery message:", message)
+	u.logger.Trace("Broadcasting discovery message:", message)
 	u.discoveryCounter++
 	for _, server := range u.servers {
 		for _, target := range server.discoveryTargets {
@@ -378,7 +378,7 @@ func (u *UdpServer) BroadcastDiscoveryMessage() {
 			if _, err := server.conn.WriteToUDP([]byte(message), destAddr); err != nil {
 				u.logger.Error("Error broadcasting discovery message to:", destAddr, " error:", err)
 			} else {
-				u.logger.Debug("Discovery message sent to:", destAddr)
+				u.logger.Trace("Discovery message sent to:", destAddr)
 			}
 		}
 	}


### PR DESCRIPTION
…d of Debug

- Updated logging statements in gossip, TCPTransporter, TcpWriter, and UdpServer to use Trace level for more granular logging.
- Enhanced visibility into the internal workings of the transport layer without cluttering logs with Debug level messages.
- Ensured consistency in logging practices across the codebase for better maintainability and readability.