### PR TITLE
Feat: Ability to pass propagate .meta during event emit/broadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,26 @@ func main() {
 $ go get github.com/moleculer-go/moleculer
 ```
 
+## Event Meta Propagation
+
+`EventOptions` is added to broker event APIs to propagate context metadata so consumers
+can read values from `ctx.meta`:
+
+```go
+bkr.Emit("event.name", payload, moleculer.EventOptions{
+  Groups: []string{"eventhub"},
+  Meta:   payload.New(map[string]interface{}{"source": "watcher"}),
+})
+bkr.Broadcast("event.name", payload, moleculer.EventOptions{
+  Groups: []string{"eventhub"},
+  Meta:   payload.New(map[string]interface{}{"source": "watcher"}),
+})
+```
+
+When `EventOptions.Meta` is provided, metadata is attached to the event context and
+serialized through transit as `meta`, compatible with Moleculer runtimes that
+expose it in event handlers (e.g. `ctx.meta` in Moleculer JS).
+
 # Running examples
 
 ```bash

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -552,21 +552,43 @@ func (broker *ServiceBroker) Call(actionName string, params interface{}, opts ..
 	return broker.registry.LoadBalanceCall(actionContext, opts...)
 }
 
-func (broker *ServiceBroker) Emit(event string, params interface{}, groups ...string) {
-	broker.logger.Trace("Broker - Emit() event: ", event, " params: ", params, " groups: ", groups)
+func (broker *ServiceBroker) Emit(event string, params interface{}, opts ...moleculer.EventOptions) {
+	groups := []string(nil)
+	var meta moleculer.Payload
+	if len(opts) > 0 {
+		groups = opts[0].Groups
+		if opts[0].Meta != nil && opts[0].Meta.Len() > 0 {
+			meta = opts[0].Meta
+		}
+	}
+	broker.logger.Trace("Broker - Emit() event: ", event, " params: ", params, " groups: ", groups, " hasMeta: ", meta != nil)
 	if !broker.IsStarted() {
 		panic(errors.New("Broker must be started before emiting events :("))
 	}
 	newContext := broker.rootContext.ChildEventContext(event, payload.New(params), groups, false)
+	if meta != nil {
+		newContext.UpdateMeta(newContext.Meta().AddMany(meta.RawMap()))
+	}
 	broker.registry.LoadBalanceEvent(newContext)
 }
 
-func (broker *ServiceBroker) Broadcast(event string, params interface{}, groups ...string) {
-	broker.logger.Trace("Broker - Broadcast() event: ", event, " params: ", params, " groups: ", groups)
+func (broker *ServiceBroker) Broadcast(event string, params interface{}, opts ...moleculer.EventOptions) {
+	groups := []string(nil)
+	var meta moleculer.Payload
+	if len(opts) > 0 {
+		groups = opts[0].Groups
+		if opts[0].Meta != nil && opts[0].Meta.Len() > 0 {
+			meta = opts[0].Meta
+		}
+	}
+	broker.logger.Trace("Broker - Broadcast() event: ", event, " params: ", params, " groups: ", groups, " hasMeta: ", meta != nil)
 	if !broker.IsStarted() {
 		panic(errors.New("Broker must be started before broadcasting events :("))
 	}
 	newContext := broker.rootContext.ChildEventContext(event, payload.New(params), groups, true)
+	if meta != nil {
+		newContext.UpdateMeta(newContext.Meta().AddMany(meta.RawMap()))
+	}
 	broker.registry.BroadcastEvent(newContext)
 }
 

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -3,7 +3,9 @@ package broker_test
 import (
 	"errors"
 	"fmt"
+	"time"
 
+	"github.com/moleculer-go/moleculer/payload"
 	"github.com/moleculer-go/moleculer/transit/memory"
 	log "github.com/sirupsen/logrus"
 
@@ -189,5 +191,36 @@ var _ = Describe("Broker", func() {
 
 		Expect(result.Value()).Should(Equal(actionResult))
 
+	})
+
+	It("Should propagate meta with EventOptions", func() {
+		metaSeen := make(chan string, 1)
+
+		bkr := broker.New(&moleculer.Config{LogLevel: "ERROR"})
+		bkr.Publish(moleculer.ServiceSchema{
+			Name: "metaReceiver",
+			Events: []moleculer.Event{
+				{
+					Name: "meta.event",
+					Handler: func(ctx moleculer.Context, params moleculer.Payload) {
+						metaSeen <- ctx.Meta().Get("origin").String()
+					},
+				},
+			},
+		})
+
+		bkr.Start()
+		defer bkr.Stop()
+
+		bkr.Emit("meta.event", map[string]interface{}{"ok": true}, moleculer.EventOptions{
+			Meta: payload.New(map[string]interface{}{"origin": "events-watcher"}),
+		})
+
+		select {
+		case got := <-metaSeen:
+			Expect(got).Should(Equal("events-watcher"))
+		case <-time.After(time.Second):
+			Fail("timed out waiting for meta.event")
+		}
 	})
 })

--- a/context/contextFactory.go
+++ b/context/contextFactory.go
@@ -266,15 +266,37 @@ func (context *Context) Call(actionName string, params interface{}, opts ...mole
 }
 
 // Emit : Emit an event (grouped & balanced global event)
-func (context *Context) Emit(eventName string, params interface{}, groups ...string) {
-	context.Logger().Debug("Context Emit() eventName: ", eventName)
+func (context *Context) Emit(eventName string, params interface{}, opts ...moleculer.EventOptions) {
+	groups := []string(nil)
+	var meta moleculer.Payload
+	if len(opts) > 0 {
+		groups = opts[0].Groups
+		if opts[0].Meta != nil && opts[0].Meta.Len() > 0 {
+			meta = opts[0].Meta
+		}
+	}
+	context.Logger().Debug("Context Emit() eventName: ", eventName, " groups: ", groups)
 	newContext := context.ChildEventContext(eventName, payload.New(params), groups, false)
+	if meta != nil {
+		newContext.UpdateMeta(newContext.Meta().AddMany(meta.RawMap()))
+	}
 	context.broker.EmitEvent(newContext)
 }
 
 // Broadcast : Broadcast an event for all local & remote services
-func (context *Context) Broadcast(eventName string, params interface{}, groups ...string) {
+func (context *Context) Broadcast(eventName string, params interface{}, opts ...moleculer.EventOptions) {
+	groups := []string(nil)
+	var meta moleculer.Payload
+	if len(opts) > 0 {
+		groups = opts[0].Groups
+		if opts[0].Meta != nil && opts[0].Meta.Len() > 0 {
+			meta = opts[0].Meta
+		}
+	}
 	newContext := context.ChildEventContext(eventName, payload.New(params), groups, true)
+	if meta != nil {
+		newContext.UpdateMeta(newContext.Meta().AddMany(meta.RawMap()))
+	}
 	context.broker.BroadcastEvent(newContext)
 }
 

--- a/examples/math/math.service.go
+++ b/examples/math/math.service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/moleculer-go/moleculer"
+	"github.com/moleculer-go/moleculer/payload"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -71,6 +72,8 @@ func addAction(context moleculer.Context, params moleculer.Payload) interface{} 
 		"a":      a,
 		"b":      b,
 		"result": result,
+	}, moleculer.EventOptions{
+		Meta: payload.New(map[string]interface{}{"source": "math.add"}),
 	})
 
 	return result
@@ -95,6 +98,8 @@ func multAction(context moleculer.Context, params moleculer.Payload) interface{}
 		"a":      a,
 		"b":      b,
 		"result": result,
+	}, moleculer.EventOptions{
+		Meta: payload.New(map[string]interface{}{"source": "math.mult"}),
 	})
 
 	return result
@@ -109,6 +114,8 @@ func subAction(context moleculer.Context, params moleculer.Payload) interface{} 
 		"a":      a,
 		"b":      b,
 		"result": result,
+	}, moleculer.EventOptions{
+		Meta: payload.New(map[string]interface{}{"source": "math.sub"}),
 	})
 	return result
 }

--- a/moleculer.go
+++ b/moleculer.go
@@ -335,12 +335,17 @@ type Options struct {
 	NodeID string
 }
 
+type EventOptions struct {
+	Meta   Payload
+	Groups []string
+}
+
 type Context interface {
 	//context methods used by services
 	MCall(map[string]map[string]interface{}) chan map[string]Payload
 	Call(actionName string, params interface{}, opts ...Options) chan Payload
-	Emit(eventName string, params interface{}, groups ...string)
-	Broadcast(eventName string, params interface{}, groups ...string)
+	Emit(eventName string, params interface{}, opts ...EventOptions)
+	Broadcast(eventName string, params interface{}, opts ...EventOptions)
 	Logger() *log.Entry
 
 	Payload() Payload
@@ -360,7 +365,8 @@ type Registry interface {
 
 type BrokerContext interface {
 	Call(actionName string, params interface{}, opts ...Options) chan Payload
-	Emit(eventName string, params interface{}, groups ...string)
+	Emit(eventName string, params interface{}, opts ...EventOptions)
+	Broadcast(eventName string, params interface{}, opts ...EventOptions)
 
 	ChildActionContext(actionName string, params Payload, opts ...Options) BrokerContext
 	ChildEventContext(eventName string, params Payload, groups []string, broadcast bool) BrokerContext

--- a/registry/eventCatalog.go
+++ b/registry/eventCatalog.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/moleculer-go/moleculer"
@@ -163,16 +164,44 @@ func findLocal(events []EventEntry) *EventEntry {
 	return nil
 }
 
+func wildcardEventKeyMatches(pattern string, eventName string) bool {
+	if !strings.HasPrefix(pattern, "*.") {
+		return false
+	}
+	// Moleculer wildcard listener format "*.EventName" should match
+	// canonical emitted names like "target.EventName".
+	return strings.HasSuffix(eventName, pattern[1:])
+}
+
+func (eventCatalog *EventCatalog) matchingEvents(name string) []EventEntry {
+	var matched []EventEntry
+
+	if events, exists := eventCatalog.events.Load(name); exists {
+		matched = append(matched, events.([]EventEntry)...)
+	}
+
+	eventCatalog.events.Range(func(key, value interface{}) bool {
+		pattern, ok := key.(string)
+		if !ok || !wildcardEventKeyMatches(pattern, name) {
+			return true
+		}
+		matched = append(matched, value.([]EventEntry)...)
+		return true
+	})
+
+	return matched
+}
+
 // Find find all events registered in this node and use the strategy to select and return the best one to be called.
 func (eventCatalog *EventCatalog) Find(name string, groups []string, preferLocal bool, localOnly bool, stg strategy.Strategy) []*EventEntry {
-	events, exists := eventCatalog.events.Load(name)
-	if !exists {
+	events := eventCatalog.matchingEvents(name)
+	if len(events) == 0 {
 		return make([]*EventEntry, 0)
 	}
 	eventCatalog.logger.Trace("event: ", name, " started: ", events)
 
 	// Sort events by nodeID to ensure deterministic order
-	eventList := events.([]EventEntry)
+	eventList := events
 	sort.Slice(eventList, func(i, j int) bool {
 		return eventList[i].targetNodeID < eventList[j].targetNodeID
 	})

--- a/registry/eventCatalog_test.go
+++ b/registry/eventCatalog_test.go
@@ -34,4 +34,24 @@ var _ = Describe("Event Catalog", func() {
 		catalog.Add(srv.Events()[0], srv, true)
 		Expect(catalog).ShouldNot(BeNil())
 	})
+
+	It("Should match wildcard event listeners for canonical event names", func() {
+		catalog := registry.CreateEventCatalog(log.New().WithField("catalog", "events"))
+
+		srv := service.FromSchema(moleculer.ServiceSchema{
+			Name: "eventhub",
+			Events: []moleculer.Event{
+				{
+					Name:    "*.AssetCreated",
+					Handler: handler,
+				},
+			},
+		}, test.DelegatesWithId("node-test-1"))
+		srv.SetNodeID("node-test-1")
+		catalog.Add(srv.Events()[0], srv, true)
+
+		entries := catalog.Find("central-storage.AssetCreated", nil, true, false, nil)
+		Expect(entries).Should(HaveLen(1))
+		Expect(entries[0].TargetNodeID()).Should(Equal("node-test-1"))
+	})
 })


### PR DESCRIPTION
This PR address #118 

- Added `EventOptions` to event APIs so `Emit`/`Broadcast` can carry both groups and meta.
- Propagated `EventOptions.Meta` into event context so receivers can read it from `ctx.meta` (including JS side).
- Added wildcard event resolution in `EventCatalog` so listeners like `*.MyEvent` match canonical emitted names like `service.MyEvent`.
- Updated docs/tests/examples to reflect new API and behavior.