### PR TITLE
fix: guard nil type assertions in populateFromMap and UpdateFromMap

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -461,8 +461,18 @@ func (service *Service) AddEventMap(eventInfo map[string]interface{}) *Event {
 
 // UpdateFromMap update the service metadata and settings from a serviceInfo map
 func (service *Service) UpdateFromMap(serviceInfo map[string]interface{}) {
-	service.settings = serviceInfo["settings"].(map[string]interface{})
-	service.metadata = serviceInfo["metadata"].(map[string]interface{})
+	if s, ok := serviceInfo["settings"].(map[string]interface{}); ok {
+		service.settings = s
+	} else {
+		log.Warnf("Remote service %q on node %q sent invalid settings — defaulting to empty map", service.name, service.nodeID)
+		service.settings = map[string]interface{}{}
+	}
+	if m, ok := serviceInfo["metadata"].(map[string]interface{}); ok {
+		service.metadata = m
+	} else {
+		log.Warnf("Remote service %q on node %q sent invalid metadata — defaulting to empty map", service.name, service.nodeID)
+		service.metadata = map[string]interface{}{}
+	}
 }
 
 // AddSettings add settings to the service. it will be merged with the

--- a/service/service.go
+++ b/service/service.go
@@ -494,13 +494,13 @@ func populateFromMap(service *Service, serviceInfo map[string]interface{}) {
 	if s, ok := serviceInfo["settings"].(map[string]interface{}); ok {
 		service.settings = s
 	} else {
-		log.Warnf("populateFromMap: service %q has nil/invalid settings from node %q — defaulting to empty map", service.name, service.nodeID)
+		log.Warnf("Remote service %q on node %q sent invalid settings — defaulting to empty map", service.name, service.nodeID)
 		service.settings = map[string]interface{}{}
 	}
 	if m, ok := serviceInfo["metadata"].(map[string]interface{}); ok {
 		service.metadata = m
 	} else {
-		log.Warnf("populateFromMap: service %q has nil/invalid metadata from node %q — defaulting to empty map", service.name, service.nodeID)
+		log.Warnf("Remote service %q on node %q sent invalid metadata — defaulting to empty map", service.name, service.nodeID)
 		service.metadata = map[string]interface{}{}
 	}
 	if actions, ok := serviceInfo["actions"].(map[string]interface{}); ok {
@@ -508,22 +508,22 @@ func populateFromMap(service *Service, serviceInfo map[string]interface{}) {
 			if actionInfo, ok := item.(map[string]interface{}); ok {
 				service.AddActionMap(actionInfo)
 			} else {
-				log.Warnf("populateFromMap: service %q action entry is nil/invalid — skipping", service.name)
+				log.Warnf("Remote service %q on node %q sent an invalid action entry — skipping", service.name, service.nodeID)
 			}
 		}
 	} else {
-		log.Warnf("populateFromMap: service %q has nil/invalid actions from node %q — skipping", service.name, service.nodeID)
+		log.Warnf("Remote service %q on node %q sent invalid actions — skipping", service.name, service.nodeID)
 	}
 	if events, ok := serviceInfo["events"].(map[string]interface{}); ok {
 		for _, item := range events {
 			if eventInfo, ok := item.(map[string]interface{}); ok {
 				service.AddEventMap(eventInfo)
 			} else {
-				log.Warnf("populateFromMap: service %q event entry is nil/invalid — skipping", service.name)
+				log.Warnf("Remote service %q on node %q sent an invalid event entry — skipping", service.name, service.nodeID)
 			}
 		}
 	} else {
-		log.Warnf("populateFromMap: service %q has nil/invalid events from node %q — skipping", service.name, service.nodeID)
+		log.Warnf("Remote service %q on node %q sent invalid events — skipping", service.name, service.nodeID)
 	}
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -491,18 +491,39 @@ func populateFromMap(service *Service, serviceInfo map[string]interface{}) {
 			service.version)
 	}
 
-	service.settings = serviceInfo["settings"].(map[string]interface{})
-	service.metadata = serviceInfo["metadata"].(map[string]interface{})
-	actions := serviceInfo["actions"].(map[string]interface{})
-	for _, item := range actions {
-		actionInfo := item.(map[string]interface{})
-		service.AddActionMap(actionInfo)
+	if s, ok := serviceInfo["settings"].(map[string]interface{}); ok {
+		service.settings = s
+	} else {
+		log.Warnf("populateFromMap: service %q has nil/invalid settings from node %q — defaulting to empty map", service.name, service.nodeID)
+		service.settings = map[string]interface{}{}
 	}
-
-	events := serviceInfo["events"].(map[string]interface{})
-	for _, item := range events {
-		eventInfo := item.(map[string]interface{})
-		service.AddEventMap(eventInfo)
+	if m, ok := serviceInfo["metadata"].(map[string]interface{}); ok {
+		service.metadata = m
+	} else {
+		log.Warnf("populateFromMap: service %q has nil/invalid metadata from node %q — defaulting to empty map", service.name, service.nodeID)
+		service.metadata = map[string]interface{}{}
+	}
+	if actions, ok := serviceInfo["actions"].(map[string]interface{}); ok {
+		for _, item := range actions {
+			if actionInfo, ok := item.(map[string]interface{}); ok {
+				service.AddActionMap(actionInfo)
+			} else {
+				log.Warnf("populateFromMap: service %q action entry is nil/invalid — skipping", service.name)
+			}
+		}
+	} else {
+		log.Warnf("populateFromMap: service %q has nil/invalid actions from node %q — skipping", service.name, service.nodeID)
+	}
+	if events, ok := serviceInfo["events"].(map[string]interface{}); ok {
+		for _, item := range events {
+			if eventInfo, ok := item.(map[string]interface{}); ok {
+				service.AddEventMap(eventInfo)
+			} else {
+				log.Warnf("populateFromMap: service %q event entry is nil/invalid — skipping", service.name)
+			}
+		}
+	} else {
+		log.Warnf("populateFromMap: service %q has nil/invalid events from node %q — skipping", service.name, service.nodeID)
 	}
 }
 


### PR DESCRIPTION
## Problem

When a remote node registers a service that omits `Settings` or `Metadata` from its `ServiceSchema`, moleculer serialises those fields as JSON `null`. On the receiving end, `populateFromMap` and `UpdateFromMap` perform bare type assertions:

```go
service.settings = serviceInfo["settings"].(map[string]interface{})
```

This panics at runtime:

```
panic: interface conversion: interface {} is nil, not map[string]interface {}
goroutine … service.(*Service).populateFromMap(…) service/service.go:495
```

The panic takes down the entire broker process, not just the affected service.

## Root cause

Moleculer's own internal services (`$node`, `control`) and many third-party services don't set `Settings`/`Metadata`, so `null` is a valid, common value in the wire format.

## Fix

Replace bare assertions with comma-ok checks in both functions. When the value is missing or `nil`, fall back to an empty map and log a warning so the issue is visible without crashing the node.

```go
if s, ok := serviceInfo["settings"].(map[string]interface{}); ok {
    service.settings = s
} else {
    log.Warnf("Remote service %q on node %q sent invalid settings — defaulting to empty map", service.name, service.nodeID)
    service.settings = map[string]interface{}{}
}
```

The same pattern is applied to `metadata`, `actions`, and `events` in `populateFromMap`, and to `settings`/`metadata` in `UpdateFromMap`.

## Testing

Tested against a live NATS cluster where `agribank-connector-service` and moleculer's own `$node` service send `null` settings/metadata. The broker now logs warnings and continues operating instead of panicking.